### PR TITLE
Status optional get avail

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -6,15 +6,19 @@ module Types
       Language.all
     end
     
-    field :get_availabilities, [Types::AvailabilityType], null: false, description: 'Availabilities (sorted newest to oldest) by user_id and status' do
+    field :get_availabilities, [Types::AvailabilityType], null: false, description: 'Availabilities (sorted newest to oldest) by user_id' do
       argument :user_id, ID, required: true
-      argument :status, String, required: true
+      argument :status, String, required: false
     end
 
-    def get_availabilities(user_id:, status:)
-      ::Availability
-        .where(user_id: user_id, status: status)
+    def get_availabilities(params)
+      if params[:status]
+        Availability.where(user_id: params[:user_id], status: params[:status])
         .order(start_date_time: :asc)
+      else
+        Availability.where(user_id: params[:user_id])
+        .order(start_date_time: :asc)
+      end
     end
 
     field :get_user, Types::UserType, null: false, description: 'Returns a single user by id' do

--- a/spec/queries/availability/get_availabilities_spec.rb
+++ b/spec/queries/availability/get_availabilities_spec.rb
@@ -14,7 +14,33 @@ RSpec.describe Types::QueryType, type: :request do
       @cancelled = Availability.create(user: @user, start_date_time: @start_dt_1, end_date_time: @end_dt_1, status: 2 )
     end
 
-    it "can query user's availabilities by status open and order by date asc" do
+    it "can query all user's availabilities" do
+      query = <<~GQL
+        query {
+          getAvailabilities(
+            userId: "#{@user.id}"
+          ) {
+            userId
+            id
+            startDateTime
+            endDateTime
+            status
+            createdAt
+            updatedAt
+          }
+        }
+      GQL
+
+      post '/graphql', params: { query: query }
+
+      result = JSON.parse(response.body, symbolize_names: true)
+      expect(result[:data][:getAvailabilities].size).to eq(4)
+      result[:data][:getAvailabilities].each do |avail|
+        expect(avail[:userId]).to eq(@user.id.to_s)
+      end
+    end
+
+    it "can query user's availabilities by status open" do
       post graphql_path, params: { query: query(user_id: @user.id, status: 'open') }
 
       result = JSON.parse(response.body, symbolize_names: true)

--- a/spec/queries/availability/get_availabilities_spec.rb
+++ b/spec/queries/availability/get_availabilities_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Types::QueryType, type: :request do
         }
       GQL
 
-      post '/graphql', params: { query: query }
+      post graphql_path, params: { query: query }
 
       result = JSON.parse(response.body, symbolize_names: true)
       expect(result[:data][:getAvailabilities].size).to eq(4)

--- a/spec/queries/availability/get_availabilities_spec.rb
+++ b/spec/queries/availability/get_availabilities_spec.rb
@@ -1,60 +1,80 @@
-require "rails_helper"
-module Types
-    RSpec.describe ::Availability, type: :request do 
-        before :each do
-            @user = User.create(id: "1", email:"john@email.com", username: "John", password:"1234")
-            @start_dt_1 = DateTime.new(2020, 12, 25, 1, 30).to_i
-            @end_dt_1 = DateTime.new(2020, 12, 25, 3, 30).to_i
-            @start_dt_2 = DateTime.new(2020, 12, 27, 1, 30).to_i
-            @end_dt_2 = DateTime.new(2020, 12, 27, 3, 30).to_i
-            @open = ::Availability.create(user: @user, start_date_time: @start_dt_1, end_date_time: @end_dt_1, status: 0 )
-            @open2 = ::Availability.create(user: @user, start_date_time: @start_dt_2, end_date_time: @end_dt_2, status: 0 )
-            @fulfilled = ::Availability.create(user: @user, start_date_time: @start_dt_1, end_date_time: @end_dt_1, status: 1 )
-            @cancelled = ::Availability.create(user: @user, start_date_time: @start_dt_1, end_date_time: @end_dt_1, status: 2 )
-            @get_availabilities = <<-GRAPHQL
-            query($userId: ID!, $status: String!) {
-                getAvailabilities(userId: $userId, status: $status) {
-                    userId
-                    startDateTime
-                    endDateTime
-                    status
-                }
-            }
-            GRAPHQL
-        end
+require 'rails_helper'
 
-        describe "Happy Paths -" do
-            it "can query a users availabilities by status open, and ordered by date asc" do
-                availabilities = TomoApiSchema.execute(@get_availabilities, variables: { userId: @user.id, status: "open" } )
-
-                expect(availabilities["data"]["getAvailabilities"][0]["userId"]).to eq("1")
-                expect(availabilities["data"]["getAvailabilities"][0]["startDateTime"]).to eq(@start_dt_1.to_s)
-                expect(availabilities["data"]["getAvailabilities"][0]["endDateTime"]).to eq(@end_dt_1.to_s)
-                expect(availabilities["data"]["getAvailabilities"][0]["status"]).to eq("open")
-
-                expect(availabilities["data"]["getAvailabilities"][1]["userId"]).to eq("1")
-                expect(availabilities["data"]["getAvailabilities"][1]["startDateTime"]).to eq(@start_dt_2.to_s)
-                expect(availabilities["data"]["getAvailabilities"][1]["endDateTime"]).to eq(@end_dt_2.to_s)
-                expect(availabilities["data"]["getAvailabilities"][1]["status"]).to eq("open")
-            end
-
-            it "can query a users availabilities by status fulfilled" do
-                availabilities = TomoApiSchema.execute(@get_availabilities, variables: { userId: @user.id, status: "fulfilled" } )
-
-                expect(availabilities["data"]["getAvailabilities"][0]["userId"]).to eq("1")
-                expect(availabilities["data"]["getAvailabilities"][0]["startDateTime"]).to eq(@start_dt_1.to_s)
-                expect(availabilities["data"]["getAvailabilities"][0]["endDateTime"]).to eq(@end_dt_1.to_s)
-                expect(availabilities["data"]["getAvailabilities"][0]["status"]).to eq("fulfilled")
-            end
-
-            it "can query a users availabilities by status cancelled" do
-                availabilities = TomoApiSchema.execute(@get_availabilities, variables: { userId: @user.id, status: "cancelled" } )
-
-                expect(availabilities["data"]["getAvailabilities"][0]["userId"]).to eq("1")
-                expect(availabilities["data"]["getAvailabilities"][0]["startDateTime"]).to eq(@start_dt_1.to_s)
-                expect(availabilities["data"]["getAvailabilities"][0]["endDateTime"]).to eq(@end_dt_1.to_s)
-                expect(availabilities["data"]["getAvailabilities"][0]["status"]).to eq("cancelled")
-            end
-        end
+RSpec.describe Types::QueryType, type: :request do
+  describe 'get availabilities' do
+    before :each do
+      @user = User.create(id: "1", email:"john@email.com", username: "John", password:"1234")
+      @start_dt_1 = DateTime.new(2020, 12, 25, 1, 30).to_i
+      @end_dt_1 = DateTime.new(2020, 12, 25, 3, 30).to_i
+      @start_dt_2 = DateTime.new(2020, 12, 27, 1, 30).to_i
+      @end_dt_2 = DateTime.new(2020, 12, 27, 3, 30).to_i
+      @open = Availability.create(user: @user, start_date_time: @start_dt_1, end_date_time: @end_dt_1, status: 0 )
+      @open_2 = Availability.create(user: @user, start_date_time: @start_dt_2, end_date_time: @end_dt_2, status: 0 )
+      @fulfilled = Availability.create(user: @user, start_date_time: @start_dt_1, end_date_time: @end_dt_1, status: 1 )
+      @cancelled = Availability.create(user: @user, start_date_time: @start_dt_1, end_date_time: @end_dt_1, status: 2 )
     end
+
+    it "can query user's availabilities by status open and order by date asc" do
+      post graphql_path, params: { query: query(user_id: @user.id, status: 'open') }
+
+      result = JSON.parse(response.body, symbolize_names: true)
+      avail_1 = result[:data][:getAvailabilities][0]
+      avail_2 = result[:data][:getAvailabilities][1]
+
+      expect(avail_1[:id]).to eq(@open.id.to_s)
+      expect(avail_1[:userId]).to eq(@user.id.to_s)
+      expect(avail_1[:startDateTime]).to eq(@start_dt_1.to_s)
+      expect(avail_1[:endDateTime]).to eq(@end_dt_1.to_s)
+      expect(avail_1[:status]).to eq('open')
+
+      expect(avail_2[:id]).to eq(@open_2.id.to_s)
+      expect(avail_2[:userId]).to eq(@user.id.to_s)
+      expect(avail_2[:startDateTime]).to eq(@start_dt_2.to_s)
+      expect(avail_2[:endDateTime]).to eq(@end_dt_2.to_s)
+      expect(avail_2[:status]).to eq('open')
+    end
+
+    it "can query user's availabilities by status fulfilled" do
+      post graphql_path, params: { query: query(user_id: @user.id, status: 'fulfilled') }
+      result = JSON.parse(response.body, symbolize_names: true)
+      avail_1 = result[:data][:getAvailabilities][0]
+
+      expect(avail_1[:id]).to eq(@fulfilled.id.to_s)
+      expect(avail_1[:userId]).to eq(@user.id.to_s)
+      expect(avail_1[:startDateTime]).to eq(@start_dt_1.to_s)
+      expect(avail_1[:endDateTime]).to eq(@end_dt_1.to_s)
+      expect(avail_1[:status]).to eq('fulfilled')
+    end
+
+    it "can query user's availabilities by status cancelled" do
+      post graphql_path, params: { query: query(user_id: @user.id, status: 'cancelled') }
+      result = JSON.parse(response.body, symbolize_names: true)
+      avail_1 = result[:data][:getAvailabilities][0]
+
+      expect(avail_1[:id]).to eq(@cancelled.id.to_s)
+      expect(avail_1[:userId]).to eq(@user.id.to_s)
+      expect(avail_1[:startDateTime]).to eq(@start_dt_1.to_s)
+      expect(avail_1[:endDateTime]).to eq(@end_dt_1.to_s)
+      expect(avail_1[:status]).to eq('cancelled')
+    end
+
+    def query(user_id:, status:)
+      <<~GQL
+        query {
+          getAvailabilities(
+            userId: "#{user_id}"
+            status: "#{status}"
+          ) {
+            userId
+            id
+            startDateTime
+            endDateTime
+            status
+            createdAt
+            updatedAt
+          }
+        }
+      GQL
+    end
+  end
 end


### PR DESCRIPTION
### What was changed?
- In get_availabilities spec (queries all avail for by user):
  - Convert all specs to request specs (previously testing the schema)
  - Add test for querying all avail for a user (no specified status)
- Make status optional on get availabilities query

### Have Tests Been Added?
- [ ] No.
- [ ] Yes, but all tests are not passing.
- [x] Yes, and all are passing.

### Issues:
* Closes #67

### Tracking Consistency:
- [x] Added appropriate labels
- [x] Addressed any rubocop violations
- [x] Added comments on my pull request, particularly in hard-to-understand areas
