### PR TITLE
Allow FE domain and local port 3000 to call API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 gem 'graphql'
 gem 'bcrypt'
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,8 @@ GEM
       websocket (~> 1.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.0)
@@ -278,6 +280,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pry
   puma (~> 5.0)
+  rack-cors
   rails (~> 6.1.0)
   rspec-rails
   rubocop-rails

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins 'localhost:3000', 'tomo-app.herokuapp.com'
+
+    resource '',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end

--- a/spec/factories/languages.rb
+++ b/spec/factories/languages.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :language do
-    name { Faker::ProgrammingLanguage.name }
+    name { Faker::ProgrammingLanguage.unique.name }
   end
 end


### PR DESCRIPTION
### What was changed?
- Allow the FE domain or local host 3000 to call the backend API

### Have Tests Been Added?
- [x] No.
- [ ] Yes, but all tests are not passing.
- [ ] Yes, and all are passing.

### Tracking Consistency:
- [x] Added appropriate labels
- [x] Addressed any rubocop violations
- [x] Added comments on my pull request, particularly in hard-to-understand areas
